### PR TITLE
DropDown 컴포넌트 구현 

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -12,6 +12,7 @@ module.exports = {
             "@styles": path.resolve(__dirname, "src/styles"),
             "@utils": path.resolve(__dirname, "src/utils"),
             "@hooks": path.resolve(__dirname, "src/hooks"),
+            "@contexts": path.resolve(__dirname, "src/contexts"),
         },
     },
 };

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -10,7 +10,8 @@
             "@ui": ["./src/ui"],
             "@styles": ["./src/styles"],
             "@utils": ["./src/utils"],
-            "@hooks": ["./src/hooks"]
+            "@hooks": ["./src/hooks"],
+            "@contexts": ["./src/contexts"]
         }
     }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import FontStyles from "@styles/fontStyles";
 import GlobalStyle from "@styles/GlobalStyle";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
@@ -7,8 +7,6 @@ import koKR from "antd/locale/ko_KR";
 
 import NewScheduleForm from "@components/NewScheduleForm";
 import MainLayout from "@pages/MainLayout";
-import { clickAwayContext } from "@contexts";
-import { styled } from "styled-components";
 
 const router = createBrowserRouter([
     {
@@ -49,12 +47,6 @@ const router = createBrowserRouter([
 ]);
 
 export default function App(params) {
-    const [clickedElement, setClickedElement] = useState(null);
-
-    function handleAppClicked(e) {
-        setClickedElement(e.target);
-    }
-
     return (
         <React.StrictMode>
             <FontStyles />
@@ -68,14 +60,8 @@ export default function App(params) {
                     },
                 }}
             >
-                <clickAwayContext.Provider value={{ clickedElement }}>
-                    <ClickAwayListener onClick={handleAppClicked}>
-                        <RouterProvider router={router} />
-                    </ClickAwayListener>
-                </clickAwayContext.Provider>
+                <RouterProvider router={router} />
             </ConfigProvider>
         </React.StrictMode>
     );
 }
-
-const ClickAwayListener = styled.div``;

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import FontStyles from "@styles/fontStyles";
+import GlobalStyle from "@styles/GlobalStyle";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { ConfigProvider } from "antd";
+import koKR from "antd/locale/ko_KR";
+
+import NewScheduleForm from "@components/NewScheduleForm";
+import MainLayout from "@pages/MainLayout";
+import { clickAwayContext } from "@contexts";
+import { styled } from "styled-components";
+
+const router = createBrowserRouter([
+    {
+        path: "/",
+        element: <MainLayout />,
+        errorElement: <div>잘못된 경로인 듯?</div>,
+        children: [
+            {
+                index: true,
+                element: <NewScheduleForm />,
+            },
+            {
+                path: "/addschedule",
+                element: <div>새 작업 추가</div>,
+            },
+            {
+                path: "/today",
+                element: <div>오늘의 일정</div>,
+            },
+            {
+                path: "/calendar",
+                element: <div>달력</div>,
+            },
+            {
+                path: "/important",
+                element: <div>중요 일정</div>,
+            },
+            {
+                path: "/groups/:groupid",
+                element: <div>그룹 일정</div>,
+            },
+        ],
+    },
+    {
+        path: "/login",
+        element: <div>Login Screen</div>,
+    },
+]);
+
+export default function App(params) {
+    const [clickedElement, setClickedElement] = useState(null);
+
+    function handleAppClicked(e) {
+        setClickedElement(e.target);
+    }
+
+    return (
+        <React.StrictMode>
+            <FontStyles />
+            <GlobalStyle />
+            <ConfigProvider
+                locale={koKR}
+                theme={{
+                    token: {
+                        fontFamily: "NanumGothic",
+                        colorPrimary: "#aad9bb",
+                    },
+                }}
+            >
+                <clickAwayContext.Provider value={{ clickedElement }}>
+                    <ClickAwayListener onClick={handleAppClicked}>
+                        <RouterProvider router={router} />
+                    </ClickAwayListener>
+                </clickAwayContext.Provider>
+            </ConfigProvider>
+        </React.StrictMode>
+    );
+}
+
+const ClickAwayListener = styled.div``;

--- a/src/assets/icons/ArrowDropDown.js
+++ b/src/assets/icons/ArrowDropDown.js
@@ -1,0 +1,7 @@
+import * as React from "react";
+const SvgComponent = (props) => (
+    <svg xmlns="http://www.w3.org/2000/svg" width={20} height={20} fill="#e8eaed" viewBox="0 -960 960 960" {...props}>
+        <path d="M480-384 288-576h384L480-384Z" />
+    </svg>
+);
+export default SvgComponent;

--- a/src/assets/icons/index.js
+++ b/src/assets/icons/index.js
@@ -14,3 +14,4 @@ export { default as SidebarUnfold } from "./SidebarUnfold";
 export { default as Star } from "./Star";
 export { default as Dot } from "./Dot";
 export { default as Check } from "./Check";
+export { default as ArrowDropDown } from "./ArrowDropDown";

--- a/src/components/newScheduleForm/newScheduleForm.jsx
+++ b/src/components/newScheduleForm/newScheduleForm.jsx
@@ -2,6 +2,7 @@ import { styled } from "styled-components";
 import { useForm } from "@hooks";
 import Button from "@ui/Button";
 import { OptionLabel, DateTimePicker } from ".";
+import { DropDown } from "@ui";
 import dayjs from "dayjs";
 
 const inputInfo = {
@@ -52,12 +53,7 @@ export default function NewScheduleForm() {
                         />
                     </OptionLabel>
                     <OptionLabel optionType="alarm">
-                        <AdditionalInfoInput
-                            placeholder="현재 알람 없음"
-                            onChange={(e) => {
-                                onInputValueChange("alarm", e.target.value);
-                            }}
-                        />
+                        <DropDown />
                     </OptionLabel>
                     <OptionLabel optionType="add"></OptionLabel>
                 </OptionList>
@@ -95,12 +91,6 @@ const OptionList = styled.div`
     display: flex;
     flex-direction: column;
     gap: 2px;
-`;
-
-const AdditionalInfoInput = styled.input`
-    flex-grow: 1;
-    border: none;
-    font-size: 1rem;
 `;
 
 const DescriptionInput = styled.textarea`

--- a/src/components/newScheduleForm/newScheduleForm.jsx
+++ b/src/components/newScheduleForm/newScheduleForm.jsx
@@ -25,35 +25,40 @@ const inputInfo = {
     },
 };
 
+const alarmList = [
+    { key: "1 minute", value: "1 minute", description: "1분 전" },
+    { key: "5 minute", value: "5 minute", description: "5분 전" },
+    { key: "10 minute", value: "10 minute", description: "10분 전" },
+    { key: "1 hour", value: "1 hour", description: "한시간 전" },
+    { key: "1 day", value: "1 day", description: "하루 전" },
+];
+
 function dummySubmit(formResult) {
     console.table(formResult);
 }
 
 export default function NewScheduleForm() {
     const { inputValues, onInputValueChange, onSubmit } = useForm(inputInfo, dummySubmit);
+
     function handleSubmit(e) {
         e.preventDefault();
         onSubmit();
     }
 
+    function generateChageHandler(key) {
+        return (newValue) => onInputValueChange(key, newValue);
+    }
+
     return (
         <FakeCon>
             <Container onSubmit={(e) => e.preventDefault()}>
-                <TitleInput
-                    placeholder="제목을 입력해주세요"
-                    onChange={(e) => {
-                        onInputValueChange("title", e.target.value);
-                    }}
-                />
+                <TitleInput placeholder="제목을 입력해주세요" onChange={generateChageHandler("title")} />
                 <OptionList>
                     <OptionLabel optionType="time">
-                        <DateTimePicker
-                            value={inputValues.time}
-                            onChange={(newValue) => onInputValueChange("time", newValue)}
-                        />
+                        <DateTimePicker value={inputValues.time} onChange={generateChageHandler("time")} />
                     </OptionLabel>
                     <OptionLabel optionType="alarm">
-                        <DropDown />
+                        <DropDown itemList={alarmList} onChange={generateChageHandler("alarm")} />
                     </OptionLabel>
                     <OptionLabel optionType="add"></OptionLabel>
                 </OptionList>

--- a/src/contexts/clickAwayContext.js
+++ b/src/contexts/clickAwayContext.js
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+
+const clickAwayDefault = { clickedElement: null };
+
+const clickAwayContext = createContext(clickAwayDefault);
+
+export default clickAwayContext;

--- a/src/contexts/index.js
+++ b/src/contexts/index.js
@@ -1,0 +1,1 @@
+export { default as clickAwayContext } from "./clickAwayContext";

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,1 +1,2 @@
 export { default as useForm } from "./useForm";
+export { default as useClickAway } from "./useClickAway";

--- a/src/hooks/useClickAway.js
+++ b/src/hooks/useClickAway.js
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+export default function useClickAway(ref, onClickAway) {
+    useEffect(() => {
+        function handleSomewhereClick(e) {
+            const clickedElement = e.target;
+            const listenerElement = ref.current;
+            if (!listenerElement.contains(clickedElement)) onClickAway(e);
+        }
+
+        document.addEventListener("click", handleSomewhereClick);
+        return () => {
+            document.removeEventListener("click", handleSomewhereClick);
+        };
+    }, [ref, onClickAway]);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,71 +1,10 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import reportWebVitals from "./reportWebVitals";
-import FontStyles from "@styles/fontStyles";
-import GlobalStyle from "@styles/GlobalStyle";
-import { createBrowserRouter, RouterProvider } from "react-router-dom";
-import { ConfigProvider } from "antd";
-import koKR from "antd/locale/ko_KR";
 
-import NewScheduleForm from "@components/NewScheduleForm";
-import MainLayout from "@pages/MainLayout";
-
-const router = createBrowserRouter([
-    {
-        path: "/",
-        element: <MainLayout />,
-        errorElement: <div>잘못된 경로인 듯?</div>,
-        children: [
-            {
-                index: true,
-                element: <NewScheduleForm />,
-            },
-            {
-                path: "/addschedule",
-                element: <div>새 작업 추가</div>,
-            },
-            {
-                path: "/today",
-                element: <div>오늘의 일정</div>,
-            },
-            {
-                path: "/calendar",
-                element: <div>달력</div>,
-            },
-            {
-                path: "/important",
-                element: <div>중요 일정</div>,
-            },
-            {
-                path: "/groups/:groupid",
-                element: <div>그룹 일정</div>,
-            },
-        ],
-    },
-    {
-        path: "/login",
-        element: <div>Login Screen</div>,
-    },
-]);
+import App from "./App";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(
-    <React.StrictMode>
-        <FontStyles />
-        <GlobalStyle />
-        <ConfigProvider
-            locale={koKR}
-            theme={{
-                token: {
-                    fontFamily: "NanumGothic",
-                    colorPrimary: "#aad9bb",
-                },
-            }}
-        >
-            <RouterProvider router={router} />
-        </ConfigProvider>
-    </React.StrictMode>
-);
+root.render(<App />);
 
 reportWebVitals();

--- a/src/ui/Button.jsx
+++ b/src/ui/Button.jsx
@@ -6,5 +6,7 @@ export default function Button({ children, ...props }) {
 
 const ButtonComponent = styled.button`
     border: none;
+    padding: 0px;
     background-color: transparent;
+    cursor: pointer;
 `;

--- a/src/ui/ClickAwayListener.jsx
+++ b/src/ui/ClickAwayListener.jsx
@@ -1,0 +1,31 @@
+import { Children, cloneElement, useEffect, useRef } from "react";
+
+export default function ClickAwayListener({ children: child, onClickAway }) {
+    const ListeningComponentRef = useRef();
+
+    function combineExistingRef(newRef) {
+        ListeningComponentRef.current = newRef;
+
+        const childRef = child.ref;
+
+        if (typeof childRef === "function") childRef(newRef);
+        else if (childRef) childRef.current = ListeningComponentRef;
+    }
+
+    useEffect(() => {
+        function handleSomewhereClick(e) {
+            const clickedElement = e.target;
+            const listenerElement = ListeningComponentRef.current;
+            if (!listenerElement.contains(clickedElement)) onClickAway(e);
+        }
+
+        document.addEventListener("click", handleSomewhereClick);
+        return () => {
+            document.removeEventListener("click", handleSomewhereClick);
+        };
+    }, [onClickAway]);
+
+    const wrppedElement = cloneElement(child, { ref: combineExistingRef });
+
+    return Children.only(wrppedElement);
+}

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -1,4 +1,4 @@
-import { Svg } from "@ui";
+import { Button, Svg } from "@ui";
 import { styled } from "styled-components";
 import { ArrowDropDown } from "@icons";
 import { useCallback, useState } from "react";
@@ -33,7 +33,9 @@ export default function DropDown({ ...props }) {
         <ClickAwayListener onClickAway={handleOutsideClick}>
             <Container onClick={handleInputClick}>
                 <TextInput placeholder="입력 없음" value={inputValue} readOnly {...props} />
-                <Svg src={ArrowDropDown} containerStyle={DropDownIconStyle} />
+                <Button>
+                    <Svg src={ArrowDropDown} containerStyle={DropDownIconStyle} />
+                </Button>
                 {showMenu && (
                     <DropDownMenu>
                         {DUMMY.map(({ key, value }) => (
@@ -52,7 +54,7 @@ export default function DropDown({ ...props }) {
     );
 }
 
-const Container = styled.label`
+const Container = styled.div`
     position: relative;
     display: flex;
     align-items: center;

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -4,15 +4,7 @@ import { ArrowDropDown } from "@icons";
 import { useCallback, useState } from "react";
 import ClickAwayListener from "./ClickAwayListener";
 
-const DUMMY = [
-    { name: "item1", key: "item1", value: "1시간 전" },
-    { name: "item2", key: "item2", value: "10분 전" },
-    { name: "item3", key: "item3", value: "5분 전" },
-    { name: "item4", key: "item4", value: "1일 전" },
-    { name: "item5", key: "item5", value: "일주일 전" },
-];
-
-export default function DropDown({ ...props }) {
+export default function DropDown({ itemList, onChange, ...props }) {
     const [showMenu, setShowMenu] = useState(false);
     const [inputValue, setInputValue] = useState("");
 
@@ -20,9 +12,10 @@ export default function DropDown({ ...props }) {
         setShowMenu((oldShowMenu) => !oldShowMenu);
     }
 
-    function handleMenuItemClick(menuValue) {
+    function handleMenuItemClick(description, menuValue) {
         setShowMenu(false);
-        setInputValue(menuValue);
+        setInputValue(description);
+        onChange(menuValue);
     }
 
     const handleOutsideClick = useCallback(() => {
@@ -38,13 +31,13 @@ export default function DropDown({ ...props }) {
                 </Button>
                 {showMenu && (
                     <DropDownMenu>
-                        {DUMMY.map(({ key, value }) => (
+                        {itemList.map(({ key, value, description }) => (
                             <MenuItem
                                 key={key}
-                                onClick={() => handleMenuItemClick(value)}
+                                onClick={() => handleMenuItemClick(description, value)}
                                 className={`${inputValue === value ? "selected" : null}`}
                             >
-                                {value}
+                                {description}
                             </MenuItem>
                         ))}
                     </DropDownMenu>

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -1,8 +1,8 @@
 import { Svg } from "@ui";
 import { styled } from "styled-components";
 import { ArrowDropDown } from "@icons";
-import { useState, useRef, useCallback } from "react";
-import { useClickAway } from "@hooks";
+import { useCallback, useState } from "react";
+import ClickAwayListener from "./ClickAwayListener";
 
 const DUMMY = [
     { name: "item1", key: "item1", value: "1시간 전" },
@@ -15,7 +15,6 @@ const DUMMY = [
 export default function DropDown({ ...props }) {
     const [showMenu, setShowMenu] = useState(false);
     const [inputValue, setInputValue] = useState("");
-    const containerRef = useRef();
 
     function handleInputClick() {
         setShowMenu((oldShowMenu) => !oldShowMenu);
@@ -26,24 +25,26 @@ export default function DropDown({ ...props }) {
         setInputValue(menuValue);
     }
 
-    const handleClickAway = useCallback(() => console.log("clicked outside"), []);
-
-    useClickAway(containerRef, handleClickAway);
+    const handleOutsideClick = useCallback(() => {
+        setShowMenu(false);
+    }, []);
 
     return (
-        <Container ref={containerRef} onClick={handleInputClick}>
-            <TextInput placeholder="입력 없음" value={inputValue} readOnly {...props} />
-            <Svg src={ArrowDropDown} containerStyle={DropDownIconStyle} />
-            {showMenu && (
-                <DropDownMenu>
-                    {DUMMY.map(({ key, value }) => (
-                        <MenuItem key={key} onClick={() => handleMenuItemClick(value)}>
-                            {value}
-                        </MenuItem>
-                    ))}
-                </DropDownMenu>
-            )}
-        </Container>
+        <ClickAwayListener onClickAway={handleOutsideClick}>
+            <Container onClick={handleInputClick}>
+                <TextInput placeholder="입력 없음" value={inputValue} readOnly {...props} />
+                <Svg src={ArrowDropDown} containerStyle={DropDownIconStyle} />
+                {showMenu && (
+                    <DropDownMenu>
+                        {DUMMY.map(({ key, value }) => (
+                            <MenuItem key={key} onClick={() => handleMenuItemClick(value)}>
+                                {value}
+                            </MenuItem>
+                        ))}
+                    </DropDownMenu>
+                )}
+            </Container>
+        </ClickAwayListener>
     );
 }
 

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -1,7 +1,8 @@
 import { Svg } from "@ui";
 import { styled } from "styled-components";
 import { ArrowDropDown } from "@icons";
-import { useState } from "react";
+import { useState, useContext, useRef, useEffect } from "react";
+import { clickAwayContext } from "@contexts";
 
 const DUMMY = [
     { name: "item1", key: "item1", value: "1시간 전" },
@@ -24,11 +25,20 @@ export default function DropDown({ ...props }) {
         setInputValue(menuValue);
     }
 
+    const containerRef = useRef();
+    const { clickedElement } = useContext(clickAwayContext);
+    const isClickedRef = useRef(false);
+
+    useEffect(() => {
+        isClickedRef.current = containerRef.current.contains(clickedElement);
+        console.log("TRIGGERED");
+    }, [clickedElement]);
+
     return (
-        <Container onClick={handleInputClick}>
+        <Container ref={containerRef} onClick={handleInputClick}>
             <TextInput placeholder="입력 없음" value={inputValue} readOnly {...props} />
             <Svg src={ArrowDropDown} containerStyle={DropDownIconStyle} />
-            {showMenu && (
+            {showMenu && isClickedRef && (
                 <DropDownMenu>
                     {DUMMY.map(({ key, value }) => (
                         <MenuItem key={key} onClick={() => handleMenuItemClick(value)}>

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -22,6 +22,12 @@ export default function DropDown({ itemList, onChange, ...props }) {
         setShowMenu(false);
     }, []);
 
+    const generateMenuItemClassName = (itemDescription) => {
+        let className = "";
+        if (itemDescription === inputValue) className += "selected ";
+        return className.trim();
+    };
+
     return (
         <ClickAwayListener onClickAway={handleOutsideClick}>
             <Container onClick={handleInputClick}>
@@ -35,7 +41,7 @@ export default function DropDown({ itemList, onChange, ...props }) {
                             <MenuItem
                                 key={key}
                                 onClick={() => handleMenuItemClick(description, value)}
-                                className={`${inputValue === value ? "selected" : null}`}
+                                className={generateMenuItemClassName(description)}
                             >
                                 {description}
                             </MenuItem>

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -1,0 +1,68 @@
+import { Svg } from "@ui";
+import { styled } from "styled-components";
+import { ArrowDropDown } from "@icons";
+
+const DUMMY = [
+    { name: "item1", key: "item1", value: "1시간 전" },
+    { name: "item2", key: "item2", value: "10분 전" },
+    { name: "item3", key: "item3", value: "5분 전" },
+    { name: "item4", key: "item4", value: "1일 전" },
+    { name: "item5", key: "item5", value: "일주일 전" },
+];
+
+export default function DropDown(props) {
+    return (
+        <Container>
+            <TextInput placeholder="입력 없음" />
+            <Svg src={ArrowDropDown} containerStyle={DropDownIconStyle} />
+            <DropDownMenu>
+                {DUMMY.map(({ key, value }) => (
+                    <MenuItem key={key}>{value}</MenuItem>
+                ))}
+            </DropDownMenu>
+        </Container>
+    );
+}
+
+const Container = styled.label`
+    position: relative;
+    display: flex;
+    align-items: center;
+`;
+
+const TextInput = styled.input`
+    padding: 0px;
+    font-size: 1rem;
+    font-family: "NanumGothic";
+    cursor: pointer;
+`;
+
+const DropDownIconStyle = {
+    width: "16px",
+    height: "16px",
+};
+
+const DropDownMenu = styled.ul`
+    position: absolute;
+    top: 1.375rem;
+    left: 0px;
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+
+    width: 62.5%;
+    min-width: 6rem;
+    padding: 0.5rem 0px;
+    margin: 0px;
+
+    border-radius: 0.5rem;
+    box-shadow: 2px 2px 20px 0px rgba(0, 0, 0, 0.175);
+    -webkit-box-shadow: 2px 2px 20px 0px rgba(0, 0, 0, 0.175);
+    -moz-box-shadow: 2px 2px 20px 0px rgba(0, 0, 0, 0.175);
+`;
+
+const MenuItem = styled.li`
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+`;

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -1,8 +1,8 @@
 import { Svg } from "@ui";
 import { styled } from "styled-components";
 import { ArrowDropDown } from "@icons";
-import { useState, useContext, useRef, useEffect } from "react";
-import { clickAwayContext } from "@contexts";
+import { useState, useRef, useCallback } from "react";
+import { useClickAway } from "@hooks";
 
 const DUMMY = [
     { name: "item1", key: "item1", value: "1시간 전" },
@@ -15,6 +15,7 @@ const DUMMY = [
 export default function DropDown({ ...props }) {
     const [showMenu, setShowMenu] = useState(false);
     const [inputValue, setInputValue] = useState("");
+    const containerRef = useRef();
 
     function handleInputClick() {
         setShowMenu((oldShowMenu) => !oldShowMenu);
@@ -25,20 +26,15 @@ export default function DropDown({ ...props }) {
         setInputValue(menuValue);
     }
 
-    const containerRef = useRef();
-    const { clickedElement } = useContext(clickAwayContext);
-    const isClickedRef = useRef(false);
+    const handleClickAway = useCallback(() => console.log("clicked outside"), []);
 
-    useEffect(() => {
-        isClickedRef.current = containerRef.current.contains(clickedElement);
-        console.log("TRIGGERED");
-    }, [clickedElement]);
+    useClickAway(containerRef, handleClickAway);
 
     return (
         <Container ref={containerRef} onClick={handleInputClick}>
             <TextInput placeholder="입력 없음" value={inputValue} readOnly {...props} />
             <Svg src={ArrowDropDown} containerStyle={DropDownIconStyle} />
-            {showMenu && isClickedRef && (
+            {showMenu && (
                 <DropDownMenu>
                     {DUMMY.map(({ key, value }) => (
                         <MenuItem key={key} onClick={() => handleMenuItemClick(value)}>

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -37,7 +37,11 @@ export default function DropDown({ ...props }) {
                 {showMenu && (
                     <DropDownMenu>
                         {DUMMY.map(({ key, value }) => (
-                            <MenuItem key={key} onClick={() => handleMenuItemClick(value)}>
+                            <MenuItem
+                                key={key}
+                                onClick={() => handleMenuItemClick(value)}
+                                className={`${inputValue === value ? "selected" : null}`}
+                            >
                                 {value}
                             </MenuItem>
                         ))}
@@ -91,4 +95,11 @@ const MenuItem = styled.li`
     padding: 0.375rem 0.75rem;
     font-size: 0.75rem;
     cursor: pointer;
+    &:hover {
+        background-color: #f0f0f0;
+    }
+
+    &.selected {
+        font-weight: bold;
+    }
 `;

--- a/src/ui/DropDown.jsx
+++ b/src/ui/DropDown.jsx
@@ -1,6 +1,7 @@
 import { Svg } from "@ui";
 import { styled } from "styled-components";
 import { ArrowDropDown } from "@icons";
+import { useState } from "react";
 
 const DUMMY = [
     { name: "item1", key: "item1", value: "1시간 전" },
@@ -10,16 +11,32 @@ const DUMMY = [
     { name: "item5", key: "item5", value: "일주일 전" },
 ];
 
-export default function DropDown(props) {
+export default function DropDown({ ...props }) {
+    const [showMenu, setShowMenu] = useState(false);
+    const [inputValue, setInputValue] = useState("");
+
+    function handleInputClick() {
+        setShowMenu((oldShowMenu) => !oldShowMenu);
+    }
+
+    function handleMenuItemClick(menuValue) {
+        setShowMenu(false);
+        setInputValue(menuValue);
+    }
+
     return (
-        <Container>
-            <TextInput placeholder="입력 없음" />
+        <Container onClick={handleInputClick}>
+            <TextInput placeholder="입력 없음" value={inputValue} readOnly {...props} />
             <Svg src={ArrowDropDown} containerStyle={DropDownIconStyle} />
-            <DropDownMenu>
-                {DUMMY.map(({ key, value }) => (
-                    <MenuItem key={key}>{value}</MenuItem>
-                ))}
-            </DropDownMenu>
+            {showMenu && (
+                <DropDownMenu>
+                    {DUMMY.map(({ key, value }) => (
+                        <MenuItem key={key} onClick={() => handleMenuItemClick(value)}>
+                            {value}
+                        </MenuItem>
+                    ))}
+                </DropDownMenu>
+            )}
         </Container>
     );
 }
@@ -28,9 +45,11 @@ const Container = styled.label`
     position: relative;
     display: flex;
     align-items: center;
+    cursor: pointer;
 `;
 
 const TextInput = styled.input`
+    width: 4.5rem;
     padding: 0px;
     font-size: 1rem;
     font-family: "NanumGothic";
@@ -38,8 +57,8 @@ const TextInput = styled.input`
 `;
 
 const DropDownIconStyle = {
-    width: "16px",
-    height: "16px",
+    width: "24px",
+    height: "24px",
 };
 
 const DropDownMenu = styled.ul`
@@ -49,11 +68,10 @@ const DropDownMenu = styled.ul`
 
     display: flex;
     flex-direction: column;
-    gap: 0.125rem;
 
     width: 62.5%;
     min-width: 6rem;
-    padding: 0.5rem 0px;
+    padding: 0.375rem 0px;
     margin: 0px;
 
     border-radius: 0.5rem;
@@ -63,6 +81,7 @@ const DropDownMenu = styled.ul`
 `;
 
 const MenuItem = styled.li`
-    padding: 0.25rem 0.75rem;
+    padding: 0.375rem 0.75rem;
     font-size: 0.75rem;
+    cursor: pointer;
 `;

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -1,0 +1,6 @@
+export { default as Button } from "./Button";
+export { default as Checkbox } from "./Checkbox";
+export { default as DropDown } from "./DropDown";
+export { default as Image } from "./Image";
+export { default as Progressbar } from "./Progressbar";
+export { default as Svg } from "./Svg";


### PR DESCRIPTION
# PR 제목

## :bulb: 개요
![DropDown](https://github.com/user-attachments/assets/cb0dc598-db53-451a-a22d-2be953751c7d)
- [x] 클릭 시 펼쳐지는 드롭다운 메뉴
- [x] 선택된 항목 강조하기
- [x] 항목 클릭 시 선택
- [x] 외부 클릭 시 줄어듬
- [x] ClickAwayListener, useClickAway 추가

## 상세 설명

useClickAway는 커스텀 훅으로, ref와 callback을 제공받아 ref 컴포넌트 외부 클릭시 callback을 호출한다
ClickAwayListener는 Wrapper 컴포넌트로, callback을 제공받아 자식 컨포넌트 외부를 클릭시 callback을 호출한다

## 배운 점

react-click-away 라이브러리를 참조하다가 시간이 오래 끌렸다
- document에 까먹고 있던 addEventListener를 쓰면 된다는 걸깨달았다
- wrapper 컴포넌트를 만드는 방법을 배웠다(CloneElement이용)
- CSS 선택자에 대해 복습했다

## 후속 작업
- [ ] 입력창 입력 가부
- [ ] 항목 위에 마우스 호버링 시 입력창 내 텍스트 변화
- [ ] item 별 disable, display 여부 지정
- [ ] 클릭 후 바로 사라지는게 아니라 강조 후 사라짐(선택했다는 걸 보여줘야하니까)

fixes #7 