### PR TITLE
Modal 컴포넌트 완성

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,34 +10,12 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>React App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="modal"></div>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -5,8 +5,8 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { ConfigProvider } from 'antd';
 import koKR from 'antd/locale/ko_KR';
 
-import NewScheduleForm from '@components/NewScheduleForm';
 import MainLayout from '@pages/MainLayout';
+import Homepage from '@pages/Homepage';
 
 const router = createBrowserRouter([
   {
@@ -16,7 +16,7 @@ const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <NewScheduleForm />,
+        element: <Homepage />,
       },
       {
         path: '/addschedule',

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,16 +1,59 @@
 import { styled } from 'styled-components';
 import { useRef } from 'react';
 import { SidebarAddSchedule } from '@icons';
+import dayjs from 'dayjs';
 
 import { Button, Svg, Modal } from '@ui';
 import { Header, SidebarMenu, GroupMenu } from '@components/Sidebar';
 import NewScheduleForm from '@components/NewScheduleForm';
+
+const formInfo = {
+  title: {
+    defaultValue: '',
+    validation: (newValue) => {
+      let errorMessage = '';
+      if (newValue.length < 1) return '제목을 입력해주세요!';
+      return errorMessage;
+    },
+    isRequired: true,
+  },
+  group: {
+    defaultValue: '',
+    validation: (newValue) => '',
+    isRequired: false,
+  },
+  time: {
+    defaultValue: dayjs(),
+    validation: (newValue) => '',
+    isRequired: false,
+  },
+  alarm: {
+    defaultValue: '',
+    validation: (newValue) => '',
+    isRequired: false,
+  },
+  description: {
+    defaultValue: '',
+    validation: (newValue) => '',
+    isRequired: true,
+  },
+};
 
 export default function Sidebar() {
   const modalRef = useRef();
 
   function handleNewScheduleClick() {
     modalRef.current.open();
+  }
+
+  function handleSubmitNewSchedule() {
+    console.log('~~Sidebar.jsx~~ submitted new schedule');
+    modalRef.current.close();
+  }
+
+  function handleCancelNewSchedule() {
+    console.log('~~Sidebar.jsx~~ canceled new schedule');
+    modalRef.current.close();
   }
 
   return (
@@ -25,7 +68,11 @@ export default function Sidebar() {
         <GroupMenu />
       </nav>
       <Modal ref={modalRef}>
-        <NewScheduleForm />
+        <NewScheduleForm
+          formInfo={formInfo}
+          onSubmit={handleSubmitNewSchedule}
+          onCancel={handleCancelNewSchedule}
+        />
       </Modal>
       <div id="modal"></div>
     </Container>

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,24 +1,30 @@
 import { styled } from 'styled-components';
-import { Link } from 'react-router-dom';
+import { useRef } from 'react';
 import { SidebarAddSchedule } from '@icons';
 
-import { Button, Svg } from '@ui';
+import { Button, Svg, Modal } from '@ui';
 import { Header, SidebarMenu, GroupMenu } from '@components/Sidebar';
 
 export default function Sidebar() {
+  const modalRef = useRef();
+
+  function handleNewScheduleClick() {
+    modalRef.current.open();
+  }
+
   return (
     <Container>
       <Header />
       <nav>
-        <AddScheduleButton>
+        <AddScheduleButton onClick={handleNewScheduleClick}>
           <Svg src={SidebarAddSchedule} alt="add schedule icon" />
-          <AddScheduleLink to="/addschedule">
-            <strong>작업 추가</strong>
-          </AddScheduleLink>
+          <strong>작업 추가</strong>
         </AddScheduleButton>
         <SidebarMenu />
         <GroupMenu />
       </nav>
+      <Modal ref={modalRef}></Modal>
+      <div id="modal"></div>
     </Container>
   );
 }
@@ -49,10 +55,4 @@ const AddScheduleButton = styled(Button)`
   filter: drop-shadow(0px 4px 4px rgb(0, 0, 0, 0.25));
 
   font-family: 'NanumSquareB';
-`;
-
-const AddScheduleLink = styled(Link)`
-  padding-left: 0.7rem;
-  text-decoration: none;
-  color: black;
 `;

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -4,6 +4,7 @@ import { SidebarAddSchedule } from '@icons';
 
 import { Button, Svg, Modal } from '@ui';
 import { Header, SidebarMenu, GroupMenu } from '@components/Sidebar';
+import NewScheduleForm from '@components/NewScheduleForm';
 
 export default function Sidebar() {
   const modalRef = useRef();
@@ -23,7 +24,9 @@ export default function Sidebar() {
         <SidebarMenu />
         <GroupMenu />
       </nav>
-      <Modal ref={modalRef}></Modal>
+      <Modal ref={modalRef}>
+        <NewScheduleForm />
+      </Modal>
       <div id="modal"></div>
     </Container>
   );

--- a/src/components/newScheduleForm/index.js
+++ b/src/components/newScheduleForm/index.js
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components';
-import dayjs from 'dayjs';
+
 import { useForm } from '@hooks';
 import { Button, Icon } from '@ui';
 import { SidebarAddSchedule } from '@icons';
@@ -36,40 +36,12 @@ const DUMMY_DATA = {
   },
 };
 
-const formInfo = {
-  title: {
-    defaultValue: '',
-    validation: (newValue) => {
-      let errorMessage = '';
-      if (newValue.length < 1) return '제목을 입력해주세요!';
-      return errorMessage;
-    },
-    isRequired: true,
-  },
-  group: {
-    defaultValue: '',
-    validation: (newValue) => '',
-    isRequired: false,
-  },
-  time: {
-    defaultValue: dayjs(),
-    validation: (newValue) => '',
-    isRequired: false,
-  },
-  alarm: {
-    defaultValue: '',
-    validation: (newValue) => '',
-    isRequired: false,
-  },
-  description: {
-    defaultValue: '',
-    validation: (newValue) => '',
-    isRequired: true,
-  },
-};
-
 export default function NewScheduleForm({
+  formInfo,
   onSubmit: submitAPI = DUMMY_DATA.dummySubmit,
+  onCancel = () => {
+    console.log('cacenled new schedule');
+  },
   ...props
 }) {
   const { inputValues, errors, onInputValueChange, onSubmit } = useForm(
@@ -102,67 +74,61 @@ export default function NewScheduleForm({
   }
 
   return (
-    <FakeCon>
-      <Container onSubmit={(e) => e.preventDefault()}>
-        <TitleInput
-          value={inputValues.title}
-          placeholder="제목을 입력해주세요"
-          onChange={(e) => onInputValueChange('title', e.target.value)}
+    <Container onSubmit={(e) => e.preventDefault()}>
+      <TitleInput
+        value={inputValues.title}
+        placeholder="제목을 입력해주세요"
+        onChange={(e) => onInputValueChange('title', e.target.value)}
+      />
+      <ScheduleOptions>
+        <ScheduleOption
+          optionType="group"
+          value={inputValues.group}
+          onChange={generateChangeHandler('group')}
+          itemList={groupInputItemList}
+          placeholder="그룹"
         />
-        <ScheduleOptions>
-          <ScheduleOption
-            optionType="group"
-            value={inputValues.group}
-            onChange={generateChangeHandler('group')}
-            itemList={groupInputItemList}
-            placeholder="그룹"
-          />
-          <ScheduleOption
-            optionType="time"
-            value={inputValues.time}
-            onChange={generateChangeHandler('time')}
-          />
-          <ScheduleOption
-            optionType="alarm"
-            value={inputValues.alarm}
-            onChange={generateChangeHandler('alarm')}
-            itemList={alarmList}
-            placeholder="알람"
-          />
-          <AddOption.Container>
-            <AddOption.Icon
-              src={SidebarAddSchedule}
-              alt="속성 추가"
-              containerWidth={24}
-              containerHeight={24}
-            />
-            <AddOption.Desc>속성 추가...</AddOption.Desc>
-          </AddOption.Container>
-          <ErrorMessage>
-            {errorMessages.map(({ name, message }) => (
-              <div key={name} className="error-message">
-                *{message}
-              </div>
-            ))}
-          </ErrorMessage>
-        </ScheduleOptions>
-        <Description
-          value={inputValues.description}
-          onChange={(e) => onInputValueChange('description', e.target.value)}
-          placeholder="일정 설명..."
+        <ScheduleOption
+          optionType="time"
+          value={inputValues.time}
+          onChange={generateChangeHandler('time')}
         />
-        <Control>
-          <CancelButton>취소</CancelButton>
-          <ConfirmButton onClick={handleSubmit}>분류</ConfirmButton>
-        </Control>
-      </Container>
-    </FakeCon>
+        <ScheduleOption
+          optionType="alarm"
+          value={inputValues.alarm}
+          onChange={generateChangeHandler('alarm')}
+          itemList={alarmList}
+          placeholder="알람"
+        />
+        <AddOption.Container>
+          <AddOption.Icon
+            src={SidebarAddSchedule}
+            alt="속성 추가"
+            containerWidth={24}
+            containerHeight={24}
+          />
+          <AddOption.Desc>속성 추가...</AddOption.Desc>
+        </AddOption.Container>
+        <ErrorMessage>
+          {errorMessages.map(({ name, message }) => (
+            <div key={name} className="error-message">
+              *{message}
+            </div>
+          ))}
+        </ErrorMessage>
+      </ScheduleOptions>
+      <Description
+        value={inputValues.description}
+        onChange={(e) => onInputValueChange('description', e.target.value)}
+        placeholder="일정 설명..."
+      />
+      <Control>
+        <CancelButton>취소</CancelButton>
+        <ConfirmButton onClick={handleSubmit}>분류</ConfirmButton>
+      </Control>
+    </Container>
   );
 }
-
-const FakeCon = styled.div`
-  width: 560px;
-`;
 
 const Container = styled.form`
   width: 100%;

--- a/src/components/newScheduleForm/index.js
+++ b/src/components/newScheduleForm/index.js
@@ -38,10 +38,8 @@ const DUMMY_DATA = {
 
 export default function NewScheduleForm({
   formInfo,
-  onSubmit: submitAPI = DUMMY_DATA.dummySubmit,
-  onCancel = () => {
-    console.log('cacenled new schedule');
-  },
+  onSubmit: submitAPI,
+  onCancel,
   ...props
 }) {
   const { inputValues, errors, onInputValueChange, onSubmit } = useForm(
@@ -79,6 +77,7 @@ export default function NewScheduleForm({
         value={inputValues.title}
         placeholder="제목을 입력해주세요"
         onChange={(e) => onInputValueChange('title', e.target.value)}
+        autoFocus
       />
       <ScheduleOptions>
         <ScheduleOption
@@ -123,7 +122,7 @@ export default function NewScheduleForm({
         placeholder="일정 설명..."
       />
       <Control>
-        <CancelButton>취소</CancelButton>
+        <CancelButton onClick={onCancel}>취소</CancelButton>
         <ConfirmButton onClick={handleSubmit}>분류</ConfirmButton>
       </Control>
     </Container>
@@ -133,6 +132,9 @@ export default function NewScheduleForm({
 const Container = styled.form`
   width: 100%;
   padding: 1rem;
+
+  position: relative;
+
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/src/components/newScheduleForm/index.js
+++ b/src/components/newScheduleForm/index.js
@@ -72,7 +72,7 @@ export default function NewScheduleForm({
   }
 
   return (
-    <Container onSubmit={(e) => e.preventDefault()}>
+    <Container onSubmit={(e) => e.preventDefault()} {...props}>
       <TitleInput
         value={inputValues.title}
         placeholder="제목을 입력해주세요"
@@ -131,7 +131,7 @@ export default function NewScheduleForm({
 
 const Container = styled.form`
   width: 100%;
-  padding: 1rem;
+  padding: 2rem;
 
   position: relative;
 

--- a/src/ui/ClickAwayListener.jsx
+++ b/src/ui/ClickAwayListener.jsx
@@ -25,7 +25,7 @@ export default function ClickAwayListener({ children: child, onClickAway }) {
     };
   }, [onClickAway]);
 
-  const wrppedElement = cloneElement(child, { ref: combineExistingRef });
+  const wrappedElement = cloneElement(child, { ref: combineExistingRef });
 
-  return Children.only(wrppedElement);
+  return Children.only(wrappedElement);
 }

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -2,9 +2,6 @@ import styles from './Modal.module.scss';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
-//TODO: 모달 정적 레이아웃 구현
-//TODO: 모달 켜는 함수 구현
-//TODO: 모달 끄는 함수 구현
 //TODO: 백드롭 구현
 //TODO: (prop에 따라) 모달 외 공간 클릭시 닫히기
 

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -1,3 +1,4 @@
+import { ClickAwayListener } from '@ui';
 import styles from './Modal.module.scss';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { createPortal } from 'react-dom';
@@ -5,7 +6,7 @@ import { createPortal } from 'react-dom';
 //TODO: 백드롭 구현
 //TODO: (prop에 따라) 모달 외 공간 클릭시 닫히기
 
-const Modal = forwardRef(function ResultModal({ children }, ref) {
+const Modal = forwardRef(function ResultModal({ children, ...props }, ref) {
   const dialog = useRef();
 
   useImperativeHandle(ref, () => {
@@ -19,9 +20,15 @@ const Modal = forwardRef(function ResultModal({ children }, ref) {
     };
   });
 
+  function handleBackdropClick(e) {
+    if (e.target === dialog.current) dialog.current.close();
+  }
+
   return createPortal(
-    <dialog ref={dialog} className={styles.modal}>
-      {children}
+    <dialog ref={dialog} className={styles.modal} {...props}>
+      <ClickAwayListener onClickAway={handleBackdropClick}>
+        <div>{children}</div>
+      </ClickAwayListener>
     </dialog>,
     document.getElementById('modal'),
   );

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -3,9 +3,6 @@ import styles from './Modal.module.scss';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
-//TODO: 백드롭 구현
-//TODO: (prop에 따라) 모달 외 공간 클릭시 닫히기
-
 const Modal = forwardRef(function ResultModal({ children, ...props }, ref) {
   const dialog = useRef();
 

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -1,23 +1,30 @@
-import { forwardRef, useImperativeHandle, useRef } from "react";
-import { createPortal } from "react-dom";
+import { forwardRef, useImperativeHandle, useRef } from 'react';
+import { createPortal } from 'react-dom';
 
 const Modal = forwardRef(function ResultModal({ children }, ref) {
-    const dialog = useRef();
+  //TODO: 모달 정적 레이아웃 구현
+  //TODO: 모달 켜는 함수 구현
+  //TODO: 모달 끄는 함수 구현
+  //TODO: 백드롭 구현
+  //TODO: (prop에 따라) 모달 외 공간 클릭시 닫히기
+  const dialog = useRef();
 
-    useImperativeHandle(ref, () => {
-        return {
-            open() {
-                dialog.current.showModal();
-            },
-        };
-    });
+  useImperativeHandle(ref, () => {
+    return {
+      open() {
+        dialog.current.showModal();
+      },
+    };
+  });
 
-    return createPortal(
-        <dialog ref={dialog} className="result-modal">
-            {children}
-        </dialog>,
-        document.getElementById("modal")
-    );
+  console.log(document.getElementById('modal'));
+
+  return createPortal(
+    <dialog ref={dialog} className="result-modal">
+      {children}
+    </dialog>,
+    document.getElementById('modal'),
+  );
 });
 
 export default Modal;

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -1,12 +1,14 @@
+import styles from './Modal.module.scss';
 import { forwardRef, useImperativeHandle, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
+//TODO: 모달 정적 레이아웃 구현
+//TODO: 모달 켜는 함수 구현
+//TODO: 모달 끄는 함수 구현
+//TODO: 백드롭 구현
+//TODO: (prop에 따라) 모달 외 공간 클릭시 닫히기
+
 const Modal = forwardRef(function ResultModal({ children }, ref) {
-  //TODO: 모달 정적 레이아웃 구현
-  //TODO: 모달 켜는 함수 구현
-  //TODO: 모달 끄는 함수 구현
-  //TODO: 백드롭 구현
-  //TODO: (prop에 따라) 모달 외 공간 클릭시 닫히기
   const dialog = useRef();
 
   useImperativeHandle(ref, () => {
@@ -14,13 +16,14 @@ const Modal = forwardRef(function ResultModal({ children }, ref) {
       open() {
         dialog.current.showModal();
       },
+      close() {
+        dialog.current.close();
+      },
     };
   });
 
-  console.log(document.getElementById('modal'));
-
   return createPortal(
-    <dialog ref={dialog} className="result-modal">
+    <dialog ref={dialog} className={styles.modal}>
       {children}
     </dialog>,
     document.getElementById('modal'),

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -1,0 +1,5 @@
+import { styled } from "styled-components";
+
+export default function Modal(params) {
+    return <div>modal</div>;
+}

--- a/src/ui/Modal.jsx
+++ b/src/ui/Modal.jsx
@@ -1,5 +1,23 @@
-import { styled } from "styled-components";
+import { forwardRef, useImperativeHandle, useRef } from "react";
+import { createPortal } from "react-dom";
 
-export default function Modal(params) {
-    return <div>modal</div>;
-}
+const Modal = forwardRef(function ResultModal({ children }, ref) {
+    const dialog = useRef();
+
+    useImperativeHandle(ref, () => {
+        return {
+            open() {
+                dialog.current.showModal();
+            },
+        };
+    });
+
+    return createPortal(
+        <dialog ref={dialog} className="result-modal">
+            {children}
+        </dialog>,
+        document.getElementById("modal")
+    );
+});
+
+export default Modal;

--- a/src/ui/Modal.module.scss
+++ b/src/ui/Modal.module.scss
@@ -1,6 +1,7 @@
 .modal {
   width: fit-content;
   height: fit-content;
+  padding: 0px;
   position: relative;
   border: none;
   border-radius: 8px;

--- a/src/ui/Modal.module.scss
+++ b/src/ui/Modal.module.scss
@@ -1,0 +1,10 @@
+.modal {
+  width: fit-content;
+  height: fit-content;
+  position: relative;
+  border: none;
+  border-radius: 8px;
+  &::backdrop {
+    background-color: rgba(0, 0, 0, 0.5);
+  }
+}

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -6,3 +6,4 @@ export { default as Progressbar } from './Progressbar';
 export { default as Svg } from './Svg';
 export { default as Icon } from './Icon';
 export { default as ClickAwayListener } from './ClickAwayListener';
+export { default as Modal } from './Modal';


### PR DESCRIPTION
# PR 제목

## :bulb: 개요
![Modal](https://github.com/user-attachments/assets/68818f8d-c2d1-4779-8474-6aaa1d3db5bb)
- [ ] Modal 레이아웃 구성
- [ ] 백드롭 클릭 시 모달이 닫힘

## 상세 설명

useRef로 호출을 통제할 수 있는 모달입니다
`<Modal>` 태그 내에 원하는 내용물을 삽입하면 됩니다

어느 컴포넌트에서 호출하든지 DOM 노드 상 `id=modal` 인 태그의 하위 컴포넌트로 표현됩니다
실제로는 context 사용이나 랜더링 논리 등이 선언된 컴포넌트의 하위 컴포넌트처럼 동작하니 걱정하지 않아도 됩니다

`ref.current.open()` : 모달을 엽니다
`ref.current.close()` : 모달을 닫습니다



## 배운 점

[모달에 관한 노션 문서](https://www.notion.so/pearlgrass/11a0cee277e24708a788a86ddd4dcc0a?pvs=4)